### PR TITLE
Fall back across CTAN mirrors so a bad mirror can't lose a deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,19 +63,54 @@ jobs:
           # is allowed now that image and repo are the same release year.
           # If the live CTAN later rolls over to 2027, bump the image tag to a
           # pandoc/latex build carrying that year's TeX Live to keep them aligned.
-          tlmgr update --self
-          tlmgr install libertine \
-                  sourcecodepro \
-                  ly1 \
-                  sectsty \
-                  lastpage \
-                  hanging \
-                  beamer \
-                  beamertheme-metropolis \
-                  pgfopts \
-                  beamercolorthemeowl \
-                  noto \
-                  noto-emoji
+          #
+          # tlmgr's default repository is the mirror.ctan.org redirector, which
+          # hands out a different mirror per request. A mirror caught mid-rollover
+          # serves no texlive.tlpdb, tlmgr exits 1, and the deploy is lost with
+          # nothing on the published site to show it went stale. So try the
+          # redirector twice (it re-rolls the mirror each time), then fall back to
+          # named mirrors that track tlnet closely.
+          REPOS="https://mirror.ctan.org/systems/texlive/tlnet
+          https://mirror.ctan.org/systems/texlive/tlnet
+          https://mirror.aarnet.edu.au/pub/CTAN/systems/texlive/tlnet
+          https://ftp.fau.de/ctan/systems/texlive/tlnet
+          https://mirrors.rit.edu/CTAN/systems/texlive/tlnet
+          https://ctan.math.illinois.edu/systems/texlive/tlnet"
+
+          PACKAGES="libertine
+          sourcecodepro
+          ly1
+          sectsty
+          lastpage
+          hanging
+          beamer
+          beamertheme-metropolis
+          pgfopts
+          beamercolorthemeowl
+          noto
+          noto-emoji"
+
+          installed=""
+          for repo in $REPOS; do
+            echo "::group::tlmgr via $repo"
+            if tlmgr option repository "$repo" \
+              && tlmgr update --self \
+              && tlmgr install $PACKAGES; then
+              installed="$repo"
+            fi
+            echo "::endgroup::"
+            if [ -n "$installed" ]; then
+              echo "LaTeX dependencies installed from $installed"
+              break
+            fi
+            echo "tlmgr failed against $repo — trying the next mirror"
+            sleep 10
+          done
+
+          if [ -z "$installed" ]; then
+            echo "::error::tlmgr could not install the LaTeX dependencies from any known CTAN mirror"
+            exit 1
+          fi
 
       - name: Install Dart Sass
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,9 @@ VS Code is configured (`.vscode/settings.json`) to run `make all` on every markd
 
 ## CI / Deployment
 
-GitHub Actions (`.github/workflows/deploy.yml`) runs `make public` on push to `main` using the `pandoc/latex:3.7.0.1` Docker image and deploys the `build/` directory to GitHub Pages at <https://smcclab.github.io/thirty-nine-hundred-hci/>. The `public` target excludes `resources/` (those are not published).
+GitHub Actions (`.github/workflows/deploy.yml`) runs `make public` in the `pandoc/latex:3.10.0.0-alpine` Docker image. The `build` job runs on pushes to `main` and on pull requests; only `main` proceeds to the `deploy` job, which publishes the `build/` directory to GitHub Pages. The `public` target excludes `resources/` (those are not published).
+
+The published site is <https://smcclab.au/thirty-nine-hundred-hci/> — the `smcclab.github.io` address still works but 301-redirects to the org's custom domain.
 
 ## Upstream Template
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The build is automated via a Github Action which runs `make public` rather than 
 
 ## Deploying
 
-This repository is configured to build a "public" version of the site and deploy to a Github Pages website automatically. The output website is: <https://smcclab.github.io/thirty-nine-hundred-hci/>
+This repository is configured to build a "public" version of the site and deploy to a Github Pages website automatically. The output website is: <https://smcclab.au/thirty-nine-hundred-hci/> (the older `smcclab.github.io` address redirects here).
 
 ## Contributing
 


### PR DESCRIPTION
## Why

The site stopped publishing intermittently. Run [30143991348](https://github.com/smcclab/thirty-nine-hundred-hci/actions/runs/30143991348) (commit `685b72a`) failed with:

```
tlmgr: TLPDB::from_file could not get texlive.tlpdb from:
https://ctan.math.utah.edu/ctan/tex-archive/systems/texlive/tlnet/tlpkg/texlive.tlpdb
```

`tlmgr`'s default repository is the `mirror.ctan.org` redirector, which hands out a different mirror per request. That request drew a mirror caught mid-rollover, so `tlmgr update --self` exited 1 and took the build with it. Because `deploy` needs `build`, no deployment ran — there is no `github-pages` deployment record for `685b72a` — and the published site silently stayed on the previous commit. Nothing on the site indicates it has gone stale; the next push happened to draw a healthy mirror 12 minutes later and masked it.

Any push can lose its deploy this way.

## What changed

The install step now walks a list of repositories until one succeeds:

1. `mirror.ctan.org` (twice — the redirector re-rolls the mirror each time)
2. `mirror.aarnet.edu.au/pub/CTAN` (AARNet, closest to ANU)
3. `ftp.fau.de/ctan`
4. `mirrors.rit.edu/CTAN`
5. `ctan.math.illinois.edu`

Each attempt sets the repository, then runs `tlmgr update --self` and `tlmgr install`. Only after all six are exhausted does the step fail, with a `::error::` annotation instead of an opaque Perl message.

The installed package set is unchanged.

## Verification

- **Mirrors are reachable** — HEAD-requested `tlpkg/texlive.tlpdb` on each candidate; all return `206`. `ctan.mirror.aarnet.edu.au` returned `000` and was dropped in favour of `mirror.aarnet.edu.au/pub/CTAN`.
- **Logic exercised under `sh -e`** (what Actions uses in the Alpine container), against a stubbed `tlmgr`:
  - healthy first mirror → succeeds on attempt 1, no added cost on the happy path
  - redirector failing twice → falls through to AARNet, exits 0
  - all mirrors down → exits 1 with the error annotation
  - confirmed `set -e` does not abort early on the failing `if` condition
- **Package list is byte-identical** to the previous 12 entries.
- **YAML parses**; all build steps and the `deploy` job's `main`-only guard are intact.

This PR's own `build` job is the real test — it runs the new step in the actual container.

## Docs

Three stale facts corrected alongside: the published site is `https://smcclab.au/thirty-nine-hundred-hci/` (the `github.io` address 301-redirects there), the image is `pandoc/latex:3.10.0.0-alpine`, and builds now run on PRs with only `main` deploying.

## Not addressed

- ~15 `smcclab.github.io/...` links in `workshops/`, `assessments/` and `lectures/` content. They redirect correctly, so nothing is broken; rewriting student-facing material is a separate change.
- `https_enforced: false` on Pages — a repo setting, not code.
- A failed build still produces no signal beyond email; the site just goes quietly stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)