### PR TITLE
Report Canvas storage headroom in canvas-inspect

### DIFF
--- a/canvas/README.md
+++ b/canvas/README.md
@@ -65,8 +65,13 @@ python3 canvas/push_lectures.py --mega      # also overwrites all_lectures.pdf
 ## Notes & gotchas
 
 - **Course file quota.** The 12 lecture PDFs total ~119 MB (largest,
-  `07-interfaces.pdf`, is ~34 MB). If a push fails with a quota error, ask the
-  edtech team to raise the course file quota.
+  `07-interfaces.pdf`, is ~34 MB) against a course quota of 1 GB, so a single
+  full push has plenty of room. What is *not* confirmed is whether superseded
+  files in overwrite replacement chains keep consuming quota — if they do,
+  repeated full pushes could add up over a semester. `make canvas-inspect`
+  prints storage used/free, so run it before and after a push to see whether
+  usage grows by the pushed size or stays flat. If a push ever does fail with a
+  quota error, ask the edtech team to raise it.
 - **Replacement chains accumulate.** Each overwrite leaves the superseded file
   object behind (hidden) with the id redirecting forward. This is harmless and
   invisible to students; Canvas resolves the original linked id to the latest

--- a/canvas/inspect_course.py
+++ b/canvas/inspect_course.py
@@ -17,11 +17,22 @@ def main():
     c = Canvas()
     cid = course_id()
 
-    course, _ = c.get(f"courses/{cid}")
+    course, _ = c.get(f"courses/{cid}", params={"include[]": "storage_quota_used_mb"})
     print(f"# Course {cid}: {course.get('name')}")
     print(f"  code={course.get('course_code')}  "
           f"default_view={course.get('default_view')}  "
           f"front_page_set={bool(course.get('front_page'))}")
+
+    # A full lecture push is ~119 MB, so report headroom. This also answers
+    # whether superseded files in overwrite replacement chains keep consuming
+    # quota: run it before and after a push and compare `used`.
+    quota = course.get("storage_quota_mb")
+    used = course.get("storage_quota_used_mb")
+    if quota is not None and used is not None:
+        print(f"  storage: {used:.0f} / {quota:.0f} MB used "
+              f"({quota - used:.0f} MB free)")
+    elif quota is not None:
+        print(f"  storage quota: {quota:.0f} MB (usage not reported)")
     print()
 
     # Front page


### PR DESCRIPTION
Follow-up to #16. This change was pushed to `canvas-push-tooling` a minute after that PR was squash-merged, so it never made it onto `main` — carried over here as a cherry-pick onto current `main`.

## Why

The quota note in `canvas/README.md` said only "ask edtech to raise it if a push fails". The course quota is 1 GB and a full lecture push is ~119 MB, so a single push has ample room.

What stays unconfirmed is whether **superseded files in overwrite replacement chains keep consuming quota**. The README already notes that each `on_duplicate=overwrite` leaves the previous file object behind. If those retained bytes count, repeated full pushes would accumulate — roughly eight full pushes would approach 1 GB.

Rather than guess at Canvas's behaviour, make the tool report it.

## What changed

`inspect_course.py` now requests `storage_quota_used_mb` on the course fetch and prints headroom:

```
# Course 11488: HCI 3900
  code=COMP3900  default_view=wiki  front_page_set=True
  storage: 119 / 1024 MB used (905 MB free)
```

So `make canvas-inspect` before and after a push answers the accumulation question empirically — if usage grows by the pushed size, chains retain bytes; if it stays flat, they don't. The README note now says this instead of deferring to edtech.

## Verification

Tested offline against a stubbed API — no network calls, no token used. Three response shapes, since Canvas only returns `storage_quota_used_mb` when asked and may omit either field:

- both quota and usage present → `storage: 119 / 1024 MB used (905 MB free)`
- quota only → `storage quota: 1024 MB (usage not reported)`
- neither → line omitted, no crash

Also asserted the course fetch actually sends `include[]=storage_quota_used_mb`, since without it Canvas silently returns no usage. Module compiles.

Untested: the real API response, which needs a live token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)