### PR TITLE
Bump Pages actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         run: apk add --no-cache bash git python3 py3-pip py3-yaml make
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Restore build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ./build
           key: build-v1-${{ hashFiles('Makefile', '_config.toml', 'references.bib', 'apa.csl') }}-${{ github.sha }}
@@ -125,10 +125,12 @@ jobs:
           make public
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        # v4+ excludes dotfiles from the artifact. Nothing in build/ is a dotfile
+        # and Pages runs no Jekyll here (build_type=workflow), so no .nojekyll needed.
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './build'
 
@@ -145,4 +147,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Clears the Node 20 deprecation warnings that every run has been emitting.

## What was warning

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4,
actions/configure-pages@v5, actions/upload-artifact@v4  (build)
                                              actions/deploy-pages@v4  (deploy)
```

`actions/upload-artifact@v4` isn't referenced directly — it's nested inside `upload-pages-artifact@v3`, so it's only fixable by bumping the wrapper.

## The bumps

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/cache` | v4 | **v6** |
| `actions/configure-pages` | v5 | **v6** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |

`chetan/git-restore-mtime-action@v2` is a bash composite with no node runtime, so it was never implicated and stays put.

Verified each target tag resolves to `runs.using: node24` by reading its `action.yml` at that ref, rather than trusting version numbers. `upload-pages-artifact@v5` is a composite, and internally pins `actions/upload-artifact@v7.0.0` — which is what clears the nested warning.

## Breaking changes checked

These jump up to three majors, so I read the release notes for every intervening major. Two were relevant:

- **`upload-pages-artifact` v4 stopped including dotfiles in the artifact.** Confirmed safe here: the Makefile creates no dotfiles, local `build/` contains zero, `/.nojekyll` 404s on the live site (never existed), and Pages is `build_type=workflow` so Jekyll never runs and `.nojekyll` is irrelevant. Left an inline comment so this isn't rediscovered the hard way.
- **`deploy-pages` v4 documents requiring `actions: read`.** The existing v4 usage already deploys successfully without it, matching GitHub's own Pages starter workflow, so `permissions` is left untouched.

Also confirmed the inputs and outputs this workflow actually uses still exist at the new tags: `fetch-depth` on checkout; `path`/`key`/`restore-keys` on cache; `path` on upload-pages-artifact; and the `page_url` output on deploy-pages that feeds the `environment.url`.

`cache` v5+ and `checkout` v5+ require Actions Runner 2.327.1+, which `ubuntu-latest` is well past.

## On the Alpine container

The build job runs inside `pandoc/latex:3.10.0.0-alpine` (musl, not glibc), which is where a node runtime bump could plausibly bite. It won't: the warnings themselves say the actions were already **being forced onto Node 24**, and those runs passed — including the live deploy of `2b5ef3d`. So Node 24 in this container is already proven, and this PR just makes the declared runtime match what was happening anyway.

## Verification

YAML parses; all 10 build steps and the `deploy` job's `main`-only guard intact. This PR's own `build` job exercises checkout, cache, configure-pages and upload-pages-artifact for real. `deploy-pages@v5` is the one thing a PR can't exercise, since `deploy` is gated to `main` — it'll first run on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)