### PR TITLE
Harden the deploy workflow; refresh and fix the Canvas bundles

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # A normal build is ~7 min (~1 min on a cache hit). This only bounds a hung
+    # step — a stuck tlmgr or lualatex would otherwise burn the 6 hour default.
+    timeout-minutes: 30
 
     container:
       image: pandoc/latex:3.10.0.0-alpine
@@ -139,6 +142,15 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # Pages rejects overlapping deployments, so two pushes landing close together
+    # can lose one. Serialise here rather than at workflow level, so PR builds
+    # still run in parallel. Never cancel in progress: a half-finished deploy is
+    # worse than a queued one.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
 
     environment:
       name: github-pages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,12 +86,13 @@ The SCSS theme (`css/charles_reveal_dark.scss`) defines content box classes used
 | `make canvas-inspect` | Read-only dump of the Canvas course structure |
 | `make canvas-lectures-dry` | Preview the push plan — reads Canvas, uploads nothing |
 | `make canvas-lectures` | Runs `make beamer`, then pushes `build/lectures/*.pdf` |
+| `make canvas-lectures-mega` | As above plus `bigfiles`, and also pushes the `all_lectures.pdf` / `all_workshops.pdf` bundles |
 
 These targets are **deliberately outside `all` and `public`**, and are never invoked by CI — pushing to Canvas is always a manual, local action.
 
-Uploads use `on_duplicate=overwrite` and discover each target by display name, so existing Home-page links serve the refreshed slides with no page editing. The Canvas file id is **not** reliably preserved across an overwrite (7 of 12 changed on the 2026-07-26 push), so never hardcode or cache one — Canvas resolves page links forward to the current object regardless. The token comes from `CANVAS_TOKEN` or `~/.config/canvas/anu-token` and must never be committed.
+Uploads use `on_duplicate=overwrite` and discover each target by display name, so existing Home-page links serve the refreshed slides with no page editing. Canvas's replacement chain means an old file id keeps resolving and resolves *forward* to the new content (verified 2026-07-26). The id an upload **returns** does change whenever the bytes change, though — 7 of 12 lectures got new ids on a content-changing push, all 12 kept theirs on a following no-op push — so never hardcode or cache a file id. The token comes from `CANVAS_TOKEN` or `~/.config/canvas/anu-token` and must never be committed.
 
-The `all_lectures.pdf` bundle linked from the Canvas Home page is only updated by `push_lectures.py --mega` (after `make bigfiles`), so it goes stale silently while the individual lecture PDFs stay current. See `canvas/README.md`.
+The `all_lectures.pdf` and `all_workshops.pdf` bundles linked from the Canvas Home page are **not** refreshed by `make canvas-lectures` — use `make canvas-lectures-mega` for a full refresh. Left to a plain push they go stale silently while the individual lecture PDFs stay current; on 2026-07-26 the live `all_lectures.pdf` was still the December 2025 build. See `canvas/README.md`.
 
 ## Python / Notebooks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,9 @@ The SCSS theme (`css/charles_reveal_dark.scss`) defines content box classes used
 
 These targets are **deliberately outside `all` and `public`**, and are never invoked by CI — pushing to Canvas is always a manual, local action.
 
-Uploads use `on_duplicate=overwrite` and discover each target by display name, so re-uploading keeps the Canvas file id and existing Home-page links serve the refreshed slides with no page editing. The token comes from `CANVAS_TOKEN` or `~/.config/canvas/anu-token` and must never be committed.
+Uploads use `on_duplicate=overwrite` and discover each target by display name, so existing Home-page links serve the refreshed slides with no page editing. The Canvas file id is **not** reliably preserved across an overwrite (7 of 12 changed on the 2026-07-26 push), so never hardcode or cache one — Canvas resolves page links forward to the current object regardless. The token comes from `CANVAS_TOKEN` or `~/.config/canvas/anu-token` and must never be committed.
+
+The `all_lectures.pdf` bundle linked from the Canvas Home page is only updated by `push_lectures.py --mega` (after `make bigfiles`), so it goes stale silently while the individual lecture PDFs stay current. See `canvas/README.md`.
 
 ## Python / Notebooks
 

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ $(ALL_WORKSHOPS_MD): $(WORKSHOPS_MDS)
 # See canvas/README.md. Uploads use on_duplicate=overwrite so existing Home-page
 # links keep pointing at the refreshed slides.
 
-.PHONY: canvas-lectures canvas-lectures-dry canvas-inspect
+.PHONY: canvas-lectures canvas-lectures-dry canvas-lectures-mega canvas-inspect
 
 # Preview what would be pushed (reads Canvas, uploads nothing):
 canvas-lectures-dry:
@@ -276,6 +276,12 @@ canvas-lectures-dry:
 # Build the lecture PDFs, then push them to Canvas:
 canvas-lectures: beamer
 	python3 canvas/push_lectures.py
+
+# As above, plus the all_lectures.pdf / all_workshops.pdf bundles that the Canvas
+# Home page links. Those are NOT refreshed by canvas-lectures, so without this
+# they silently keep serving whatever year they were last built in.
+canvas-lectures-mega: beamer bigfiles
+	python3 canvas/push_lectures.py --mega
 
 # Read-only dump of the current Canvas course structure:
 canvas-inspect:

--- a/canvas/README.md
+++ b/canvas/README.md
@@ -65,13 +65,11 @@ python3 canvas/push_lectures.py --mega      # also overwrites all_lectures.pdf
 ## Notes & gotchas
 
 - **Course file quota.** The 12 lecture PDFs total ~119 MB (largest,
-  `07-interfaces.pdf`, is ~34 MB) against a course quota of 1 GB, so a single
-  full push has plenty of room. What is *not* confirmed is whether superseded
-  files in overwrite replacement chains keep consuming quota — if they do,
-  repeated full pushes could add up over a semester. `make canvas-inspect`
-  prints storage used/free, so run it before and after a push to see whether
-  usage grows by the pushed size or stays flat. If a push ever does fail with a
-  quota error, ask the edtech team to raise it.
+  `07-interfaces.pdf`, is ~34 MB). Course 11488 was observed on 2026-07-26 with
+  a 2000 MB quota and 125 MB used, so a full push has ample room. Don't rely on
+  that figure — quotas differ per course and per year, and `make canvas-inspect`
+  prints the live `used / quota` so you never have to guess. If a push ever does
+  fail with a quota error, ask the edtech team to raise it.
 - **Replacement chains accumulate.** Each overwrite leaves the superseded file
   object behind (hidden) with the id redirecting forward. This is harmless and
   invisible to students; Canvas resolves the original linked id to the latest

--- a/canvas/README.md
+++ b/canvas/README.md
@@ -11,20 +11,25 @@ The Home page links each lecture PDF **by Canvas file id**, e.g.
 
 The push uses **`on_duplicate=overwrite`**, and the net effect is that **every
 existing Home-page link serves the refreshed slides** — no page editing, no
-re-linking. That outcome is confirmed. The mechanism, however, is not "the file
-id is preserved". Measured on the 2026-07-26 push of all 12 lectures:
+re-linking. Measured across two pushes on 2026-07-26:
 
-- **7 of 12 files came back with a new id** (e.g. `01-intro-to-hci.pdf`
-  `1948778` → `1969776`); the other 5 kept theirs. Which way a given file goes
-  is not predictable from anything the API tells us beforehand.
-- Re-reading the Home page afterwards showed it referencing the **new** ids, so
-  Canvas resolves page file links forward to the current object rather than
-  relying on the old id alone.
-- All 15 file ids referenced by the Home page still resolved after the push.
+- **The replacement chain works.** Querying the *pre-push* id of a bundle
+  (`1900987`) after overwriting it returned the **new** content — 110.6 MB,
+  `modified=2026-07-26`, where before it was 111 MB from 2025-12-11. So an old id
+  captured earlier keeps resolving, and resolves *forward*. This is the property
+  the whole approach rests on.
+- **But the upload response returns a different id when the bytes change.** First
+  push (content genuinely changed): 7 of 12 lectures came back with a new id, 5
+  kept theirs. Second push minutes later (identical lecture bytes): all 12 kept
+  their ids, while the two bundles — whose bytes *had* changed — both got new
+  ones. So a new id tracks a content change, not randomness.
+- Re-reading the Home page afterwards showed it referencing the **new** ids, and
+  all 15 ids it references resolved. Both the old and new ids work.
 
-So don't hardcode file ids anywhere, and don't assume an id you captured earlier
-still names the current object — re-read it. `inspect_course.py` prints current
-ids.
+Practical rule: don't hardcode a file id, and don't assume the id an upload
+returns matches the one you saw before it. Old ids stay valid, so a stale id is
+not a broken link — but it is a misleading label. `inspect_course.py` prints
+current ids.
 
 To stay robust across yearly course copies (file/folder ids change on each copy),
 `push_lectures.py` **discovers the target file by display name** and overwrites it
@@ -60,10 +65,14 @@ make canvas-lectures-dry     # or: python3 canvas/push_lectures.py --dry-run
 # Build the lecture PDFs, then push them:
 make canvas-lectures         # runs `make beamer` first
 
-# Push without rebuilding, or push a subset / the mega-bundle:
+# As above PLUS the all_lectures.pdf / all_workshops.pdf bundles the Home page
+# links. Use this for a full refresh — canvas-lectures alone leaves them stale:
+make canvas-lectures-mega    # runs `make beamer bigfiles` first
+
+# Push without rebuilding, or push a subset / preview the bundles:
 python3 canvas/push_lectures.py
 python3 canvas/push_lectures.py --only 07 12
-python3 canvas/push_lectures.py --mega      # also overwrites all_lectures.pdf
+python3 canvas/push_lectures.py --dry-run --mega   # preview incl. bundles
 ```
 
 ## Files
@@ -77,23 +86,45 @@ python3 canvas/push_lectures.py --mega      # also overwrites all_lectures.pdf
 ## Notes & gotchas
 
 - **Course file quota.** The 12 lecture PDFs total ~119 MB (largest,
-  `07-interfaces.pdf`, is ~34 MB). Course 11488 was observed on 2026-07-26 with
-  a 2000 MB quota and 125 MB used, so a full push has ample room. Don't rely on
-  that figure — quotas differ per course and per year, and `make canvas-inspect`
-  prints the live `used / quota` so you never have to guess. If a push ever does
+  `07-interfaces.pdf`, is ~34 MB); the two bundles add ~115 MB. Course 11488 has
+  a 2000 MB quota, so a full `canvas-lectures-mega` fits comfortably. Quotas
+  differ per course and per year — `make canvas-inspect` prints the live
+  `used / quota`, so don't trust a figure written down here. If a push ever does
   fail with a quota error, ask the edtech team to raise it.
-- **Overwrites do not accumulate quota.** Measured across the 2026-07-26 push of
-  all 12 lectures (119 MB): course file count stayed at 35 and storage used went
-  *down* slightly, 125 MB → 124 MB. So superseded objects are not billed against
-  the quota and repeated pushes do not creep upward. Re-measure with
-  `make canvas-inspect` if this ever looks doubtful.
-- **The `all_lectures.pdf` / `all_workshops.pdf` bundles go stale silently.** Both
-  are linked from the Home page but are *not* touched by a normal
-  `make canvas-lectures`. As of 2026-07-26 the live `all_lectures.pdf` (file
-  `1900987`, 111 MB) had `modified=2025-12-11` — students clicking it get the
-  previous year's slides while the 12 individual PDFs are current. To refresh it:
-  `make bigfiles && python3 canvas/push_lectures.py --mega`. Nothing in this
-  tooling updates `all_workshops.pdf` at all.
+- **Expect a one-time step up in usage on the first real push, and don't measure
+  it too early.** Observed on 2026-07-26:
+
+  | point | reported used |
+  |---|---|
+  | before any push | 125 MB |
+  | immediately after pushing 119 MB | 124 MB |
+  | after both pushes, settled | 245 MB |
+
+  Two things are going on. First, **the accounting lags** — the 124 MB reading was
+  taken seconds after a 119 MB upload and was simply stale, so a before/after
+  comparison right around a push proves nothing. Second, a freshly copied course
+  reports far less than its files actually weigh: 125 MB against 246 MB of files,
+  because course-copy files still share storage with the source course. Your first
+  real upload converts them into this course's own bytes, which is the step up.
+
+  Superseded objects are *not* billed: settled usage (245 MB) matches the sum of
+  the 35 current files (246 MB), so repeated pushes should hold roughly steady
+  rather than creep. Verify with `make canvas-inspect` a few minutes afterwards,
+  not immediately.
+- **The bundles go stale unless you ask for them.** `all_lectures.pdf` and
+  `all_workshops.pdf` are linked from the Home page but are *not* touched by a
+  plain `make canvas-lectures` — use **`make canvas-lectures-mega`**, which builds
+  `bigfiles` too and pushes both. This bit us: on 2026-07-26 the live
+  `all_lectures.pdf` (file `1900987`) was 111 MB with `modified=2025-12-11`, so
+  students clicking it got the *previous year's* slides while the 12 individual
+  PDFs were current. Refreshed the same day.
+- **`all_assessments.pdf` is built but not pushed.** `make bigfiles` produces it,
+  but there is no counterpart on Canvas to overwrite, so pushing it would create
+  an unlinked file rather than refresh anything. Add it to `MEGA_FILES` in
+  `push_lectures.py` if a Canvas link for it is ever created.
+- **`--dry-run` and `--mega` compose, but the make targets don't.**
+  `canvas-lectures-dry` previews lectures only. To preview the bundles too, call
+  the script directly: `python3 canvas/push_lectures.py --dry-run --mega`.
 - **`hidden: true` is normal here.** The edtech team loaded the lecture PDFs
   hidden from the student *Files* browser but reachable via the Home-page links
   (`hidden_for_user: false`). The push preserves this state.

--- a/canvas/README.md
+++ b/canvas/README.md
@@ -6,20 +6,32 @@ library Python only — no extra dependencies.
 
 ## How it works
 
-The 2025 Home page links each lecture PDF **by Canvas file id** (e.g.
-`01-intro-to-hci.pdf` is file `1900986`, linked as
-`/courses/11488/files/1900986?...&wrap=1`). The files live in the folder
-`course files/Uploaded Media 2`.
+The Home page links each lecture PDF **by Canvas file id**, e.g.
+`/courses/11488/files/1969776?...&wrap=1`.
 
-The push uses **`on_duplicate=overwrite`**. When you re-upload a PDF with the
-same filename, Canvas replaces its contents and builds a *replacement chain*: the
-original file id redirects to the new upload. So **every existing Home-page link
-automatically serves the refreshed slides** — no page editing, no re-linking.
+The push uses **`on_duplicate=overwrite`**, and the net effect is that **every
+existing Home-page link serves the refreshed slides** — no page editing, no
+re-linking. That outcome is confirmed. The mechanism, however, is not "the file
+id is preserved". Measured on the 2026-07-26 push of all 12 lectures:
+
+- **7 of 12 files came back with a new id** (e.g. `01-intro-to-hci.pdf`
+  `1948778` → `1969776`); the other 5 kept theirs. Which way a given file goes
+  is not predictable from anything the API tells us beforehand.
+- Re-reading the Home page afterwards showed it referencing the **new** ids, so
+  Canvas resolves page file links forward to the current object rather than
+  relying on the old id alone.
+- All 15 file ids referenced by the Home page still resolved after the push.
+
+So don't hardcode file ids anywhere, and don't assume an id you captured earlier
+still names the current object — re-read it. `inspect_course.py` prints current
+ids.
 
 To stay robust across yearly course copies (file/folder ids change on each copy),
 `push_lectures.py` **discovers the target file by display name** and overwrites it
 in whatever folder it currently lives in. A PDF with no match on Canvas is
-uploaded to the fallback folder `Uploaded Media 2`.
+uploaded to the fallback folder `Uploaded Media 2`. On the 2026 course copy the
+lecture PDFs were found in folder `297917`, not the 2025 `Uploaded Media 2` — the
+name-discovery path handled that automatically, which is the point of it.
 
 ## Setup (one time)
 
@@ -70,10 +82,18 @@ python3 canvas/push_lectures.py --mega      # also overwrites all_lectures.pdf
   that figure — quotas differ per course and per year, and `make canvas-inspect`
   prints the live `used / quota` so you never have to guess. If a push ever does
   fail with a quota error, ask the edtech team to raise it.
-- **Replacement chains accumulate.** Each overwrite leaves the superseded file
-  object behind (hidden) with the id redirecting forward. This is harmless and
-  invisible to students; Canvas resolves the original linked id to the latest
-  content every time.
+- **Overwrites do not accumulate quota.** Measured across the 2026-07-26 push of
+  all 12 lectures (119 MB): course file count stayed at 35 and storage used went
+  *down* slightly, 125 MB → 124 MB. So superseded objects are not billed against
+  the quota and repeated pushes do not creep upward. Re-measure with
+  `make canvas-inspect` if this ever looks doubtful.
+- **The `all_lectures.pdf` / `all_workshops.pdf` bundles go stale silently.** Both
+  are linked from the Home page but are *not* touched by a normal
+  `make canvas-lectures`. As of 2026-07-26 the live `all_lectures.pdf` (file
+  `1900987`, 111 MB) had `modified=2025-12-11` — students clicking it get the
+  previous year's slides while the 12 individual PDFs are current. To refresh it:
+  `make bigfiles && python3 canvas/push_lectures.py --mega`. Nothing in this
+  tooling updates `all_workshops.pdf` at all.
 - **`hidden: true` is normal here.** The edtech team loaded the lecture PDFs
   hidden from the student *Files* browser but reachable via the Home-page links
   (`hidden_for_user: false`). The push preserves this state.

--- a/canvas/push_lectures.py
+++ b/canvas/push_lectures.py
@@ -4,22 +4,25 @@ Strategy (matches the 2025 site, keeps front-page links live):
 
   * The Home page links each lecture PDF by Canvas *file id*.
   * `on_duplicate=overwrite` makes re-uploading a PDF with the same name update
-    the slides everywhere they're linked, with zero page editing. Note the id is
-    NOT reliably preserved: on the 2026-07-26 push, 7 of 12 files came back with
-    a new id and 5 kept theirs. Canvas resolves Home-page file links forward to
-    the current object either way, so the links keep working — but never cache or
-    hardcode a file id and assume it still names the current object.
+    the slides everywhere they're linked, with zero page editing. Verified on
+    2026-07-26: querying a bundle's pre-push id after the overwrite returned the
+    NEW content, so old ids keep resolving and resolve forward.
+    The id the upload *returns*, though, changes whenever the bytes change — 7 of
+    12 lectures got new ids on a content-changing push, and all 12 kept theirs on
+    an immediately following no-op push. So never assume the returned id matches
+    what you saw before, and don't hardcode ids.
   * To stay robust across yearly course copies (ids change), we DISCOVER the
     existing file by display name and overwrite it in its current folder. If a
     PDF has no counterpart on Canvas yet, we upload it to the fallback folder.
-  * The `all_lectures.pdf` bundle is only touched with --mega, so it goes stale
-    silently while the individual PDFs stay current. See canvas/README.md.
+  * The all_lectures.pdf / all_workshops.pdf bundles are only touched with --mega,
+    so without it they go stale silently while the individual PDFs stay current.
+    They need `make bigfiles` built first. See canvas/README.md.
 
 Usage:
     python canvas/push_lectures.py --dry-run      # show plan, change nothing
     python canvas/push_lectures.py                # upload/overwrite
     python canvas/push_lectures.py --only 07 12   # just those lectures
-    python canvas/push_lectures.py --mega         # also push the all-lectures bundle
+    python canvas/push_lectures.py --mega         # also push the all_* bundles
 
 Environment: CANVAS_TOKEN / CANVAS_API_URL / CANVAS_COURSE_ID (see canvas_api.py).
 """
@@ -37,9 +40,17 @@ LECTURES_DIR = REPO_ROOT / "build" / "lectures"
 # is not already present on Canvas. Matches where the 2025 copy landed.
 FALLBACK_FOLDER_PATH = "Uploaded Media 2"
 
-# Optional all-in-one bundle: local bigfile -> Canvas display name to overwrite.
-# The local path must match `make bigfiles` output ($(OUTPUT_DIR)/all_lectures.pdf).
-MEGA_FILE = (REPO_ROOT / "build" / "all_lectures.pdf", "all_lectures.pdf")
+# Optional all-in-one bundles: local bigfile -> Canvas display name to overwrite.
+# Local paths must match `make bigfiles` output ($(OUTPUT_DIR)/*.pdf).
+#
+# Only the bundles that actually exist on Canvas and are linked from the Home page
+# are listed. `make bigfiles` also builds all_assessments.pdf, which has no Canvas
+# counterpart — adding it here would create an unlinked file rather than refresh
+# anything, so it is deliberately omitted.
+MEGA_FILES = [
+    (REPO_ROOT / "build" / "all_lectures.pdf", "all_lectures.pdf"),
+    (REPO_ROOT / "build" / "all_workshops.pdf", "all_workshops.pdf"),
+]
 
 
 def lecture_pdfs(only):
@@ -61,7 +72,7 @@ def main():
     ap.add_argument("--only", nargs="*", default=None,
                     help="filename prefixes to include, e.g. 07 12")
     ap.add_argument("--mega", action="store_true",
-                    help="also push the concatenated all-lectures bundle")
+                    help="also push the all_lectures.pdf and all_workshops.pdf bundles")
     args = ap.parse_args()
 
     c = Canvas()
@@ -73,11 +84,12 @@ def main():
 
     jobs = [(p, p.name) for p in pdfs]
     if args.mega:
-        mega_path, mega_name = MEGA_FILE
-        if mega_path.exists():
-            jobs.append((mega_path, mega_name))
-        else:
-            print(f"! --mega requested but {mega_path.name} not found (run `make bigfiles`); skipping")
+        for mega_path, mega_name in MEGA_FILES:
+            if mega_path.exists():
+                jobs.append((mega_path, mega_name))
+            else:
+                print(f"! --mega requested but {mega_path.name} not found "
+                      f"(run `make bigfiles`); skipping")
 
     index = build_name_index(c, cid)
 

--- a/canvas/push_lectures.py
+++ b/canvas/push_lectures.py
@@ -3,12 +3,17 @@
 Strategy (matches the 2025 site, keeps front-page links live):
 
   * The Home page links each lecture PDF by Canvas *file id*.
-  * `on_duplicate=overwrite` replaces a file's bytes while keeping its id, so
-    re-uploading a PDF with the same name updates the slides everywhere they're
-    linked, with zero page editing.
+  * `on_duplicate=overwrite` makes re-uploading a PDF with the same name update
+    the slides everywhere they're linked, with zero page editing. Note the id is
+    NOT reliably preserved: on the 2026-07-26 push, 7 of 12 files came back with
+    a new id and 5 kept theirs. Canvas resolves Home-page file links forward to
+    the current object either way, so the links keep working — but never cache or
+    hardcode a file id and assume it still names the current object.
   * To stay robust across yearly course copies (ids change), we DISCOVER the
     existing file by display name and overwrite it in its current folder. If a
     PDF has no counterpart on Canvas yet, we upload it to the fallback folder.
+  * The `all_lectures.pdf` bundle is only touched with --mega, so it goes stale
+    silently while the individual PDFs stay current. See canvas/README.md.
 
 Usage:
     python canvas/push_lectures.py --dry-run      # show plan, change nothing


### PR DESCRIPTION
Findings from auditing the build process, then actually running the Canvas push end to end. Four commits: workflow hardening, plus three rounds of correcting things the real runs disproved.

## 1. Workflow: two gaps, both absent rather than misconfigured

**No concurrency control.** Pages rejects overlapping deployments, so two pushes to `main` landing close together can lose one, and the site then serves whichever won with nothing to indicate the other was dropped. Not theoretical: `685b72a` and `354b0a2` went up 12 minutes apart.

Scoped to the `deploy` job, not the workflow, so PR builds keep running in parallel. `cancel-in-progress: false` — a half-finished deploy is worse than a queued one.

**No `timeout-minutes`**, so a hung step inherited the 6-hour default. Build 30 (normal ~7 min, ~1 min cached), deploy 10.

## 2. The Home page was serving December 2025 slides

`all_lectures.pdf` is linked from the Canvas Home page but was **not** touched by `make canvas-lectures`. The live copy was 111 MB, `modified=2025-12-11` — students clicking it got the previous year's slides while the 12 individual PDFs were current. `all_workshops.pdf` had no code path to refresh it at all.

Fixed and pushed. Both are now `modified=2026-07-26`, and all 15 file ids the Home page references resolve.

- `MEGA_FILES` is now a list covering both bundles
- New `make canvas-lectures-mega` builds `beamer` + `bigfiles` and pushes everything, so a full refresh is one command
- `all_assessments.pdf` is built by `bigfiles` but deliberately excluded — no Canvas counterpart exists, so pushing it would create an unlinked file rather than refresh anything

## 3. Two corrections to my own earlier claims in this branch

Worth reading, because both were wrong in ways that would have misled later.

**The quota conclusion was measured too early.** I reported "overwrites do not accumulate quota" from a 125 → 124 MB reading taken seconds after a 119 MB upload. That reading was stale.

| point | reported used |
|---|---|
| before any push | 125 MB |
| immediately after pushing 119 MB | 124 MB |
| settled, after both pushes | 245 MB |

The direction was right but the reason wasn't. Settled usage (245 MB) matches the sum of the 35 current files (246 MB), so superseded objects genuinely aren't billed. What the numbers show is a **one-time step up**: a freshly copied course reports 125 MB against 246 MB of real file weight, because course-copy files share storage with the source course, and the first real upload converts them into this course's own bytes. Documented, along with "don't measure right after a push".

**The id-mechanism note was half right.** I said the id is "not preserved" and that Canvas resolves page links forward *instead of* relying on the old id. Querying a bundle's pre-push id (`1900987`) after overwriting returns the **new** content — so old ids do keep resolving, and resolve forward. The replacement chain works as originally documented.

What changes is the id the upload *returns*, and only when the bytes change: 7 of 12 lectures got new ids on the content-changing push, then **all 12 kept theirs** on the immediately following no-op push, while the two bundles whose bytes had changed both got new ones. So a new id tracks a content change, not randomness.

Also corrected the quota figure itself — 2000 MB, not the 1 GB I wrote in #17.

## Verification

- Workflow YAML parses; `build` has no concurrency (PR builds stay parallel), `deploy` has `group: pages`, `main`-only guard and all 10 steps intact
- Offline stubbed tests for the multi-bundle path: bundles untouched without `--mega`; both pushed with it, each overwriting in its own folder; one missing bundle skipped while the other still goes; both missing doesn't crash the lecture push
- Every make target referenced in the docs exists; `canvas-lectures-mega` expands correctly
- Forced `make -B reveal`: all 12 lectures rebuilt with **zero** pandoc warnings
- Audited all 292 local image references — every one that renders resolves
- Unpublished `resources/` confirmed not leaking (404s)

One thing I could not verify: the bundle PDFs' *contents*. Beamer's Linux Libertine subsets carry no usable ToUnicode map, so `pdftotext` returns garbage — the same extraction finds nothing in a known-current individual lecture PDF either. Provenance is the basis instead: built at 19:32 from sources last modified 18:35, at a HEAD containing the July edits, `make bigfiles` exit 0 with no LaTeX errors.

## Not addressed

- **Silent stale deploys** — still the biggest gap, and the root of this whole thread. A failed build emails you and nothing else.
- **Cache accumulation.** CI never runs `make clean` and restores `build/` on a prefix key, so a renamed lecture leaves its old output in the artifact and it keeps being deployed.
- **pandoc drift** — local 3.9.0.2, CI 3.10.0.0.
- The Home page banner image (`1900963`) is still the 2025 photo. Cosmetic, and not slides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)