### PR TITLE
Render slide background images in the beamer PDFs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ on:
       - 'workshops/**'
       - 'resources/**'
       - 'css/**'
+      - 'filters/**'
       - 'Makefile'
       - '_config.toml'
       - 'references.bib'
@@ -51,9 +52,12 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ./build
-          key: build-v1-${{ hashFiles('Makefile', '_config.toml', 'references.bib', 'apa.csl') }}-${{ github.sha }}
+          # filters/ is in the key because a filter change alters the PDFs
+          # without touching any .md. git-restore-mtime would leave the cached
+          # PDFs looking newer than their sources, and make would skip them.
+          key: build-v1-${{ hashFiles('Makefile', '_config.toml', 'references.bib', 'apa.csl', 'filters/**') }}-${{ github.sha }}
           restore-keys: |
-            build-v1-${{ hashFiles('Makefile', '_config.toml', 'references.bib', 'apa.csl') }}-
+            build-v1-${{ hashFiles('Makefile', '_config.toml', 'references.bib', 'apa.csl', 'filters/**') }}-
 
       - name: Restore file modification times
         uses: chetan/git-restore-mtime-action@v2
@@ -88,6 +92,7 @@ jobs:
           hanging
           beamer
           beamertheme-metropolis
+          pgf
           pgfopts
           beamercolorthemeowl
           noto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ CSS for reveal.js is compiled from SCSS:
 sass css/charles_reveal_dark.scss build/lectures/charles_reveal_dark.css
 ```
 
-Beamer PDFs are built with `lualatex` and require these fonts: Linux Libertine O, Noto Sans, Noto Color Emoji. Presentations use the metropolis theme with owl color scheme at 16:9 aspect ratio.
+Beamer PDFs are built with `lualatex` and require these fonts: Linux Libertine O, Noto Sans, Noto Color Emoji. Presentations use the metropolis theme with owl color scheme at 16:9 aspect ratio. They also require `pgf`/`tikz` and `etoolbox` (both are beamer dependencies, so a standard beamer install already has them) for slide background images — see `filters/beamer-background.lua`.
 
 ## Content Structure
 
@@ -38,6 +38,7 @@ Beamer PDFs are built with `lualatex` and require these fonts: Linux Libertine O
 - `assessments/` — Assessment specs (`.md`), built to HTML + PDF
 - `workshops/` — Tutorial/workshop activities (`.md`), built to HTML only
 - `resources/` — Supplementary resources (`.md`), built to HTML only
+- `filters/` — pandoc Lua filters (`beamer-background.lua`), applied via `BEAMER_OPTS`
 - Each content directory has its own `img/` subdirectory — images **cannot be shared across directories**
 - `references.bib` — Shared BibTeX references (APA citation style via `apa.csl`)
 - `_config.toml` — Course metadata (title, institution, author, year) used by `generate_index.py`
@@ -50,7 +51,12 @@ Lecture slides use pandoc's Markdown with `--slide-level 2`:
 - `##` headings create regular slides
 - `###` and below are content within a slide
 
-Lecture frontmatter includes title-slide background images:
+Reveal.js-specific syntax is supported (e.g., `{.columns}`, `{.column width="50%"}`, `background-image=` on headings).
+
+### Slide Background Images
+
+Backgrounds render in **both** reveal.js and Beamer PDF output from the same source. Title slide, from the frontmatter:
+
 ```yaml
 ---
 title: "Slide Title"
@@ -61,7 +67,17 @@ title-slide-attributes:
 ---
 ```
 
-Reveal.js-specific syntax is supported (e.g., `{.columns}`, `{.column width="50%"}`, `background-image=` on headings).
+Any `#` (section) or `##` (slide) heading, via attributes:
+
+```markdown
+## My Slide {background-image="img/hero.jpg" background-size="cover" background-opacity="0.4"}
+```
+
+`background-size` is `cover` (default, fills the slide and crops the overflow) or `contain` (whole image, letterboxed). `background-opacity` takes 0.0–1.0 and is useful when heading text would otherwise sit on a busy photo.
+
+The PDF side is `filters/beamer-background.lua`, wired in through `BEAMER_OPTS`. Beamer has no native equivalent of these attributes, so without the filter the backgrounds are silently dropped from the PDFs while still appearing in the HTML. Read the strategy comment at the top of the filter before changing it: the mechanism depends on *where* pandoc places raw blocks relative to `\begin{frame}`, and the obvious implementations fail in ways that are easy to miss — a background landing on the wrong slide, or an extra blank slide.
+
+One known gap: a background on an `{.unnumbered}` `#` heading is skipped (with a warning on stderr), because section pages are keyed by section number and unnumbered sections don't advance the counter.
 
 Citations use pandoc format: `[@bibtex-key]`, `[@bibtex-key, p26]`. References go in `references.bib`; referencing style is APA (`apa.csl`).
 
@@ -125,3 +141,4 @@ This repo is based on <https://github.com/smcclab/pandoc-course-template>. To sy
 3. Preserve these local divergences:
    - CSS is `css/charles_reveal_dark.scss` — keep this name throughout the Makefile (template uses `reveal_dark.scss`)
    - `.vscode/settings.json` keeps `python-envs.*` and `cSpell.words` settings
+   - `filters/beamer-background.lua` is a local rewrite — **do not overwrite it with the template's copy.** The template version (sha `6de3627`, checked 2026-07-26) arms a single global `\bgpendingimage` macro before each frame, which the PDF only expands at shipout. That mis-renders any deck with more than one background: the arming block for the next slide is absorbed into the current slide's body and wins the race, and when the first background heading opens the document the block becomes a frame of its own — a blank slide. Both were reproduced here before the rewrite. If the template later fixes this properly, diff the two before adopting it.

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ ASSESSMENTS_DIR = assessments
 WORKSHOPS_DIR   = workshops
 RESOURCES_DIR   = resources
 TEMPLATES_DIR   = templates
+FILTERS_DIR     = filters
 OUTPUT_DIR      = build
 IMAGE_DIR       = img
 
@@ -58,13 +59,19 @@ REVEAL_OPTS = -t revealjs \
               -V slideNumber=true \
               --css charles_reveal_dark.css
 
+# Beamer has no native equivalent of reveal.js's background-image attributes, so
+# a Lua filter translates them into TikZ background overlays. Without it the
+# backgrounds are silently dropped from the PDFs.
+BEAMER_FILTER = $(FILTERS_DIR)/beamer-background.lua
+
 BEAMER_OPTS = -t beamer \
               -V aspectratio=169 \
               -V theme=metropolis \
               -V colortheme=owl \
               --pdf-engine=lualatex \
               -V mainfont="Noto Sans" \
-              -V mainfontfallback="NotoColorEmoji:mode=harf"
+              -V mainfontfallback="NotoColorEmoji:mode=harf" \
+              --lua-filter=$(BEAMER_FILTER)
 
 # --pdf-engine=xelatex
 
@@ -117,7 +124,7 @@ $(LECTURES_OUT)/%.html: $(LECTURES_DIR)/%.md
 .PHONY: beamer
 beamer: $(LECTURES_OUT) $(BEAMER_PDFS)
 
-$(LECTURES_OUT)/%.pdf: $(LECTURES_DIR)/%.md
+$(LECTURES_OUT)/%.pdf: $(LECTURES_DIR)/%.md $(BEAMER_FILTER)
 	$(PANDOC) $(PANDOC_COMMON_OPTS) $(BEAMER_OPTS) $< -o $@
 
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Content developers (e.g., course convenors, lecturers, tutors, learning designer
 
 Images can be placed with in an `img` directory associated with each of the above. You can't reference an image across directories. So for example an image in `lectures/img` can't be used in a workshop, you'll have to duplicate the file annoyingly.
 
+A lecture slide can take a full-bleed background image, and it shows up in both the HTML slides and the PDF:
+
+    ## Slide Title {background-image="img/hero.jpg"}
+
+This works on `#` section headings too, and the title slide gets one from `title-slide-attributes` in the frontmatter. Add `background-size="contain"` to fit the whole image in rather than cropping it, and `background-opacity="0.4"` to fade it back when the heading is hard to read over the photo.
+
 All course content should be include references to textbooks, online resources and scholarly publications. The references should go in the common `references.bib` file in bibtex format. You can cite using [pandoc's citation format (see link)](https://pandoc.org/MANUAL.html#extension-citations), e.g., `[@bibtex-key, p26]` etc. The referencing format is APA using `apa.csl`.
 
 (NB: I know we ask the students to use ACM style, but the ACM csl uses numerical citations while author/date is more convenient for these kind fo documents where we want to know what the reference is without looking it up continually).

--- a/filters/beamer-background.lua
+++ b/filters/beamer-background.lua
@@ -1,0 +1,271 @@
+-- beamer-background.lua
+--
+-- Adds per-slide, section-page and title-slide background image support for
+-- Beamer PDF output. It reads the same attributes reveal.js already uses, so a
+-- deck gets the same backgrounds in both output formats with no change to the
+-- Markdown source.
+--
+-- Supported attributes on `#` and `##` headings:
+--   background-image="img/foo.jpg"        (required; data-background-image also accepted)
+--   background-size="cover"               (optional; "cover" or "contain", default: cover)
+--   background-opacity="0.4"              (optional; 0.0–1.0, default: 1.0)
+--
+-- Title slide background comes from the frontmatter:
+--   title-slide-attributes:
+--     data-background-image: img/foo.jpg
+--     data-background-size: cover         (optional)
+--     data-background-opacity: "0.4"      (optional)
+--
+-- Example:
+--   ## My Slide {background-image="img/hero.jpg" background-size="cover"}
+--
+-- ── Strategy ─────────────────────────────────────────────────────────────────
+-- Beamer paints \setbeamertemplate{background} beneath everything else on the
+-- page, so that is the layer we use. The theme's own `background canvas` is
+-- never touched, which leaves the metropolis/owl colours intact.
+--
+-- The template is installed exactly once, in the preamble, as an indirection
+-- through a single macro:
+--
+--     \setbeamertemplate{background}{\bgcurrent}
+--
+-- \bgcurrent is expanded at *shipout*, not where it is set, and a beamer frame
+-- ships out at its \end{frame} — after its entire body has been read. So a
+-- frame renders whatever \bgcurrent holds at the end of its body:
+--
+--   * \BeforeBeginEnvironment{frame} clears \bgcurrent, so every frame starts
+--     out with no background image.
+--   * A frame that wants one carries \gdef\bgcurrent{...} as the first block of
+--     its own body. Nothing later can overwrite that before the frame ships,
+--     and the assignment is global so the frame group cannot swallow it.
+--
+-- Setting \bgcurrent from *inside* the body, rather than arming a flag before
+-- the frame, is what makes this reliable. Pandoc — not this filter — decides
+-- where frames begin and end, and a raw block emitted before a heading does not
+-- land where you would hope: it is absorbed into the *previous* frame's body,
+-- or, at the very start of the document, becomes a frame of its own and shows
+-- up in the PDF as a blank slide.
+--
+-- \frame{\titlepage} and \frame{\sectionpage} are the command form of the
+-- environment, so they never trip \BeforeBeginEnvironment{frame}, and neither
+-- has a body this filter can write into. They are handled separately:
+--   * the title background is set in \AtBeginDocument and survives until the
+--     first real \begin{frame} clears it;
+--   * section backgrounds are stored in the preamble under the section number
+--     and picked up by a patched \beamer@atbeginsection, which keeps them out
+--     of the block stream entirely.
+
+local function is_opaque(opacity)
+  return opacity == nil or opacity == "" or opacity == "1" or opacity == "1.0"
+end
+
+-- Resolve an image path to absolute so lualatex can find it regardless of the
+-- temp directory it runs from. Relative paths are resolved against the
+-- directory containing the first input file.
+local function resolve_image_path(image)
+  if pandoc.path.is_absolute(image) then return image end
+  local input = PANDOC_STATE and PANDOC_STATE.input_files and PANDOC_STATE.input_files[1]
+  if not input then return image end
+  local base = pandoc.path.directory(pandoc.path.join({
+    pandoc.system.get_working_directory(), input
+  }))
+  return pandoc.path.join({base, image})
+end
+
+-- Preamble: the fitting macros, the one-time template install, and the hooks
+-- that clear or supply \bgcurrent for each kind of frame.
+--
+-- \bgcoverimage reproduces CSS/reveal.js `cover`: scale the image so it fills
+-- the slide with no gap and let the excess run off the edge (the surrounding
+-- \clip discards it). Scaling to \paperwidth and measuring the result answers
+-- "which dimension is the constraining one?" without any ratio arithmetic, and
+-- the measured box is reused when width turns out to be the answer.
+local PREAMBLE = [[
+\usepackage{etoolbox}
+\usepackage{tikz}
+\newsavebox\bgmeasurebox
+\newcommand\bgcoverimage[1]{%
+  \sbox\bgmeasurebox{\includegraphics[width=\paperwidth]{#1}}%
+  \ifdim\ht\bgmeasurebox<\paperheight
+    \includegraphics[height=\paperheight]{#1}%
+  \else
+    \usebox\bgmeasurebox
+  \fi}
+\newcommand\bgcontainimage[1]{%
+  \includegraphics[width=\paperwidth,height=\paperheight,keepaspectratio]{#1}}
+% #1 = node options ([opacity=...] or empty), #2 = fit macro, #3 = image path
+\newcommand\bgoverlay[3]{%
+  \begin{tikzpicture}[remember picture,overlay]
+    \clip (current page.south west) rectangle (current page.north east);
+    \node#1 at (current page.center) {#2{#3}};
+  \end{tikzpicture}}
+\gdef\bgcurrent{}
+\setbeamertemplate{background}{\bgcurrent}
+% Every frame starts clean; a frame with a background re-arms \bgcurrent itself.
+\BeforeBeginEnvironment{frame}{\gdef\bgcurrent{}}
+% Section pages are reached through \frame{\sectionpage}, which the environment
+% hook above never sees. \beamer@atbeginsection runs after \c@section has been
+% stepped, so the section number selects the right stored background; sections
+% without one resolve to \relax and render nothing. Both hook variants are
+% patched because beamer picks between them on whether the section title is
+% blank.
+\makeatletter
+\preto\beamer@atbeginsection{%
+  \gdef\bgcurrent{\csname bgsection@\the\c@section\endcsname}}
+\preto\beamer@atbeginsections{%
+  \gdef\bgcurrent{\csname bgsection@\the\c@section\endcsname}}
+\makeatother]]
+
+-- The TikZ overlay for one background, with the image path baked in literally.
+-- Nothing here is read from a mutable macro, so one slide's background can
+-- never be confused with another's.
+local function overlay_latex(image, size, opacity)
+  local node_opts = ""
+  if not is_opaque(opacity) then
+    node_opts = string.format("[opacity=%s]", opacity)
+  end
+  local fit = (size == "contain") and "\\bgcontainimage" or "\\bgcoverimage"
+  return string.format("\\bgoverlay{%s}{%s}{%s}", node_opts, fit, image)
+end
+
+-- Read background attributes off a heading, accepting the data- prefixed
+-- spellings reveal.js also allows.
+local function background_of(attr)
+  local function get(name)
+    return attr.attributes[name] or attr.attributes["data-" .. name]
+  end
+  local image = get("background-image")
+  if not image then return nil end
+  return {
+    image   = resolve_image_path(image),
+    size    = get("background-size"),
+    opacity = get("background-opacity"),
+  }
+end
+
+local function strip_background_attrs(attr)
+  for _, name in ipairs({ "background-image", "background-size", "background-opacity" }) do
+    attr.attributes[name] = nil
+    attr.attributes["data-" .. name] = nil
+  end
+end
+
+-- Prepend an item to a MetaList (or create one from a single value).
+local function prepend_header_include(meta, raw_latex)
+  local item = pandoc.MetaBlocks({ pandoc.RawBlock("latex", raw_latex) })
+  local hi = meta["header-includes"]
+  if hi == nil then
+    meta["header-includes"] = pandoc.MetaList({ item })
+  elseif hi.t == "MetaList" then
+    table.insert(hi, 1, item)
+  else
+    meta["header-includes"] = pandoc.MetaList({ item, hi })
+  end
+end
+
+-- Title-slide background: \frame{\titlepage} has no body to write into, so set
+-- \bgcurrent at the start of the document and let the first \begin{frame} (or
+-- the first section page) clear it.
+local function title_bg_latex(bg)
+  return string.format("\\AtBeginDocument{\\gdef\\bgcurrent{%s}}",
+    overlay_latex(bg.image, bg.size, bg.opacity))
+end
+
+-- Section-page background, stored under the section number the heading will get.
+local function section_bg_latex(number, bg)
+  return string.format("\\expandafter\\gdef\\csname bgsection@%d\\endcsname{%s}",
+    number, overlay_latex(bg.image, bg.size, bg.opacity))
+end
+
+local function is_unnumbered(attr)
+  for _, class in ipairs(attr.classes) do
+    if class == "unnumbered" then return true end
+  end
+  return false
+end
+
+function Pandoc(doc)
+  if FORMAT ~= "beamer" then return nil end
+
+  local new_blocks    = {}
+  local section_bgs   = {}
+  local section_count = 0
+  local used          = false
+
+  for _, block in ipairs(doc.blocks) do
+    if block.t == "Header" and block.level == 1 then
+      -- Level 1 becomes \section, whose separator page is generated by beamer
+      -- rather than appearing in this block list. Count the sections that
+      -- \c@section will count, and file any background under that number.
+      local numbered = not is_unnumbered(block.attr)
+      if numbered then section_count = section_count + 1 end
+
+      local bg = background_of(block.attr)
+      if bg then
+        strip_background_attrs(block.attr)
+        if numbered then
+          used = true
+          table.insert(section_bgs, section_bg_latex(section_count, bg))
+        else
+          -- Unnumbered sections never advance \c@section, so there is no key to
+          -- file the background under. Drop it rather than mis-assign it.
+          io.stderr:write(string.format(
+            "[beamer-background] ignoring background on unnumbered section %q\n",
+            pandoc.utils.stringify(block.content)))
+        end
+      end
+      table.insert(new_blocks, block)
+
+    elseif block.t == "Header" and block.level == 2 then
+      -- Level 2 becomes a frame. Arm the background as the first block of that
+      -- frame's own body, where no other slide can reach it.
+      local bg = background_of(block.attr)
+      table.insert(new_blocks, block)
+      if bg then
+        used = true
+        strip_background_attrs(block.attr)
+        table.insert(new_blocks, pandoc.RawBlock("latex",
+          string.format("\\gdef\\bgcurrent{%s}",
+            overlay_latex(bg.image, bg.size, bg.opacity))))
+      end
+
+    else
+      table.insert(new_blocks, block)
+    end
+  end
+
+  -- Title slide background from the frontmatter.
+  local title_latex = nil
+  local title_attrs = doc.meta["title-slide-attributes"]
+  if title_attrs then
+    local image, size, opacity
+    for k, v in pairs(title_attrs) do
+      local val = pandoc.utils.stringify(v)
+      if k == "data-background-image" then
+        image = val
+      elseif k == "data-background-size" then
+        size = val
+      elseif k == "data-background-opacity" then
+        opacity = val
+      end
+    end
+    if image then
+      used = true
+      title_latex = title_bg_latex({
+        image = resolve_image_path(image), size = size, opacity = opacity,
+      })
+    end
+  end
+
+  if not used then return nil end
+
+  -- Order matters: PREAMBLE defines \bgoverlay and the fit macros, so it is
+  -- prepended last to land above everything that calls them.
+  if title_latex then prepend_header_include(doc.meta, title_latex) end
+  for i = #section_bgs, 1, -1 do
+    prepend_header_include(doc.meta, section_bgs[i])
+  end
+  prepend_header_include(doc.meta, PREAMBLE)
+
+  return pandoc.Pandoc(new_blocks, doc.meta)
+end


### PR DESCRIPTION
The reveal.js HTML has always honoured `background-image` on headings and `title-slide-attributes` in the frontmatter. Beamer has no equivalent, so pandoc silently dropped every one of them — the PDFs went out with plain dark slides where the HTML showed a photo. That includes every lecture's title slide, and it's the version students download and the version pushed to Canvas.

Adds `filters/beamer-background.lua`, which translates those attributes into TikZ overlays on beamer's `background` template, wired in through `BEAMER_OPTS`. The theme's own `background canvas` is left alone, so the metropolis/owl colours are unchanged.

## Why this isn't the template's filter

The upstream template ([smcclab/pandoc-course-template](https://github.com/smcclab/pandoc-course-template), sha `6de3627`) already ships a `beamer-background.lua`. I installed it verbatim first, and it mis-renders any deck with more than one background.

It arms a global `\bgpendingimage` before each frame and installs a template that reads it — but the template body is only expanded at *shipout*, and pandoc decides where frames begin and end. Two races follow:

1. A raw block emitted before a heading is absorbed into the **previous** frame's body, so the next slide's `\gdef` runs first and wins. A slide renders its neighbour's image.
2. When a background heading opens the document there's no previous frame to absorb the block, so pandoc gives it a frame of its own — a blank slide.

Lecture 01 showed both: *Acknowledgement of Country* carried the synth photo instead of Canberra, behind a black page 2. The template's own example lecture has exactly one content background and doesn't start with it, which is precisely the case that hides this.

So the mechanism here is a rewrite. The template is installed once in the preamble as an indirection through `\bgcurrent`, and each frame sets `\bgcurrent` globally from *inside its own body*. A frame ships out at its `\end{frame}`, after its whole body has been read, so the value can't be clobbered by a later slide and nothing extra enters the block stream. `\frame{\titlepage}` and `\frame{\sectionpage}` have no body and never trip `\BeforeBeginEnvironment{frame}`, so title slides use `\AtBeginDocument` and section pages are keyed by section number into `\beamer@atbeginsection`. The full reasoning is in a strategy comment at the top of the filter — the failure modes are subtle enough to be worth recording.

Beyond fixing the bugs this gains:

- **`#` section-page backgrounds** — lecture 04's `# Interviews` now has its photo
- **`cover` that actually covers** — scale to fill and crop, rather than stretching to the slide. `reflection.jpg` is 3:2 on a 16:9 slide and was visibly distorted
- **`contain`** and **`background-opacity`**

## Build plumbing

The beamer PDF rule now depends on the filter, and `filters/` is added to the CI path trigger and the build-cache key. A filter change alters every PDF without touching any `.md`, so otherwise a filter-only commit rebuilds nothing locally, and CI restores stale PDFs from the cache that `git-restore-mtime` makes look newer than their sources. `pgf` is listed explicitly in the tlmgr packages — it already arrives as a `beamer` dependency, but the filter uses `tikz` directly.

## Testing

Verified against a deck covering every combination: title slide, background on the first slide, adjacent slides with different images, reset to a plain slide, section page, section *without* a background, `contain`, and opacity. Then all 12 lectures rebuilt clean, with lecture 01 dropping from 63 to 62 pages as the blank slide disappeared, and no blank pages anywhere.

The same fix is up at [smcclab/pandoc-course-template#27](https://github.com/smcclab/pandoc-course-template/pull/27), where CI has gone green and I checked the artifact it produced — the filter's `tikz`/`etoolbox` needs are satisfied in the alpine container by the `beamer` dependency chain. The two copies of the filter are currently byte-identical, so a future template sync is a no-op for that file.

One known gap, noted in `CLAUDE.md`: a background on an `{.unnumbered}` `#` heading is skipped with a warning on stderr, since section pages are keyed by section number and unnumbered sections don't advance the counter. Nothing in this repo hits it.

## Note on `ci/harden-deploy`

That branch's other four commits are already in `main` via the #19 squash, so this PR is the background commit alone, cherry-picked onto `main`. `ci/harden-deploy` can be deleted once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
