### PR TITLE
Relocate the conceptualising-interaction slides out of lecture 1

### DIFF
--- a/lectures/01-intro-to-hci.md
+++ b/lectures/01-intro-to-hci.md
@@ -539,63 +539,25 @@ Images from the paper "Never Too Old: Engaging Retired People Inventing the Futu
 :::
 ::::::::::::::
 
-## Conceptual Models
+## So, what can we do?
 
 :::::::::::::: {.columns}
 ::: {.column width="60%"}
+_Back to the three things from the start of the lecture._
 
-- **Model:** a simplified description of a system or process
-- **Conceptual model:** high-level description of how a system is organized and operates
-- Includes:
-  - Metaphors, analogies
-  - Concepts and their relationships
-  - Mappings
-- These elements inform the interaction design and user experiences
+1. **Understanding** how people use computers
+    - interviewing, observing, surveying, analysing
+2. **Designing** interfaces
+    - the design process, ideation, prototyping, interface types
+3. **Evaluating** interfaces
+    - usability goals, user experience, testing with people
 
+Your three assignments are one of each: **Prototype**, **User Research**, **Final Project**.
+
+Next week: how do we actually _do_ design?
 :::
 ::: {.column width="40%"}
-![[Understanding conceptual models](https://uxdesign.cc/understanding-mental-and-conceptual-models-in-product-design-7d69de3cae26)](img/01_02_conceptualising_interaction_1.png)
-:::
-::::::::::::::
-
-## Video: What is a conceptual model?
-
-![[What is a mental model? (NNGroup)](https://www.youtube.com/watch?v=nAgXISssAws)
-](img/01_02_conceptualising_interaction_0.png){width=60%}
-
-## Interface Metaphors
-
-:::::::::::::: {.columns}
-::: {.column width="40%"}
-Exploit similarities to user's knowledge of other domains. E.g.,
-
-- **Cards:**  Familiar, strong associations (playing, business, credit), flick through, sort, themed, structured
-- **Desktop** and **Recycle bin**
-- **Shopping trolley** and **checkout**
-- **_Surfing the web_**
-:::
-::: {.column width="60%"}
-![A highly metaphorical interface. [@gentner-anti-mac:1996]](img/gentner-anti-mac-interface.jpg){width=100%}
-:::
-::::::::::::::
-
-## Interaction Types
-
-:::::::::::::: {.columns}
-::: {.column width="40%"}
-Five types of interaction models:
-
-- Instructing
-- Conversing
-- Manipulating
-- Exploring
-- Responding
-
-:::
-::: {.column width="60%"}
-![Image source: [Uriel Soberanes](https://unsplash.com/@soberanes)](img/01_02_conceptualising_interaction_7.jpg){width=30%}
-![Image source: [Fikri Rasyid](https://unsplash.com/@fikrirasyid)](img/01_02_conceptualising_interaction_8.jpg){width=30%}
-![Image source: [Szabo Viktor](https://unsplash.com/@vmxhu)](img/01_02_conceptualising_interaction_9.jpg){width=30%}
+![Human meets computer?](img/human-robot-interaction.jpg)
 :::
 ::::::::::::::
 

--- a/lectures/02-design.md
+++ b/lectures/02-design.md
@@ -572,6 +572,22 @@ Prepare for this question: "Why is that bad?"
 :::
 ::::::::::::::
 
+## Analogies in practice: interface metaphors
+
+:::::::::::::: {.columns}
+::: {.column width="40%"}
+Exploit similarities to user's knowledge of other domains. E.g.,
+
+- **Cards:**  Familiar, strong associations (playing, business, credit), flick through, sort, themed, structured
+- **Desktop** and **Recycle bin**
+- **Shopping trolley** and **checkout**
+- **_Surfing the web_**
+:::
+::: {.column width="60%"}
+![A highly metaphorical interface. [@gentner-anti-mac:1996]](img/gentner-anti-mac-interface.jpg){width=100%}
+:::
+::::::::::::::
+
 ## 13. SCAMPER
 
 > Substitute,  Combine, Adapt, Modify, Put to another use, Eliminate, Reverse (SCAMPER)

--- a/lectures/07-interfaces.md
+++ b/lectures/07-interfaces.md
@@ -204,6 +204,26 @@ Focus of interface can change:
 :::
 ::::::::::::::
 
+## Interaction Types
+
+:::::::::::::: {.columns}
+::: {.column width="40%"}
+There are many interfaces, but only a handful of ways of _interacting_ with them [@rogers-beyond-hci:2023]:
+
+- Instructing
+- Conversing
+- Manipulating
+- Exploring
+- Responding
+
+:::
+::: {.column width="60%"}
+![Image source: [Uriel Soberanes](https://unsplash.com/@soberanes)](img/01_02_conceptualising_interaction_7.jpg){width=30%}
+![Image source: [Fikri Rasyid](https://unsplash.com/@fikrirasyid)](img/01_02_conceptualising_interaction_8.jpg){width=30%}
+![Image source: [Szabo Viktor](https://unsplash.com/@vmxhu)](img/01_02_conceptualising_interaction_9.jpg){width=30%}
+:::
+::::::::::::::
+
 ## 45 years of interface types!
 
 :::::::::::::: {.columns}

--- a/lectures/09-cognitive-social-emotional.md
+++ b/lectures/09-cognitive-social-emotional.md
@@ -309,12 +309,31 @@ Learning theory concept: "zone of proximal development"---we should get users in
 
 # Cognitive Frameworks
 
-- **Mental models**
+- **Conceptual models** (the designer's side) and **mental models** (the user's side)
 - **Gulfs of Execution and Evaluation**
 - **Information Processing**
 - **Distributed Cognition**
 - **External Cognition**
 - **Embodied Interaction**
+
+## Conceptual Models
+
+:::::::::::::: {.columns}
+::: {.column width="60%"}
+
+- **Model:** a simplified description of a system or process
+- **Conceptual model:** high-level description of how a system is organized and operates
+- Includes:
+  - Metaphors, analogies
+  - Concepts and their relationships
+  - Mappings
+- This is the _designer's_ model, expressed through the interface — the user builds their own _mental_ model from it
+
+:::
+::: {.column width="40%"}
+![[Understanding conceptual models](https://uxdesign.cc/understanding-mental-and-conceptual-models-in-product-design-7d69de3cae26)](img/01_02_conceptualising_interaction_1.png)
+:::
+::::::::::::::
 
 ## Mental Models
 
@@ -332,6 +351,11 @@ A mental model is our internal understanding of how a system works.
 ![[Mental Models (nngroup)](https://www.nngroup.com/articles/mental-models/)](img/mental-models-nngroup.jpg){width=80%}
 :::
 ::::::::::::::
+
+## Video: What is a mental model?
+
+![[What is a mental model? (NNGroup)](https://www.youtube.com/watch?v=nAgXISssAws)
+](img/01_02_conceptualising_interaction_0.png){width=60%}
 
 ## Gulfs of Execution and Evaluation
 


### PR DESCRIPTION
The last four slides of lecture 1 — Conceptual Models, the "what is a conceptual model?" video, Interface Metaphors, Interaction Types — were the remains of a separate deck spliced onto the end of the usability/UX material. The image filenames are still `01_02_conceptualising_interaction_*` while everything above them is `01_01_usability_*`.

They sat under the section heading *"What can we do to ensure good usability and good user experience?"* without answering it. Design Principles and Understanding Users answer that question; conceptual models describe an interaction once you have one. The lecture then ended on them, with no return to its own framing.

## Changes

| Slide | From | To |
|---|---|---|
| Conceptual Models | L1 | L9, before Mental Models / Gulfs |
| NNGroup video | L1 | L9, retitled *What is a mental model?* |
| Interface Metaphors | L1 | L2, after Analogies / Provocation |
| Interaction Types | L1 | L7, after the Interface Types opener |

**Lecture 9** now runs conceptual model (designer's) → mental model (user's) → the gulfs between them. The conceptual-models slide is reframed to set up that pair, and the framework list gains a matching bullet.

**The video slide is also a bug fix.** In L1 it was titled *"What is a conceptual model?"* but linked to NNGroup's *"What is a mental model?"* — the two halves of Norman's distinction, silently swapped. It keeps the link and gets the right title.

**Lecture 2** gets metaphor as a worked example of the analogy technique it has just introduced, which puts it in students' hands before Assignment 1 rather than presenting it as a lens.

**Lecture 7** gets the five interaction types right after the section opener that already mentions "interaction style", as the axis orthogonal to the 22 interface types listed on the next slide.

**Lecture 1** now closes by returning to the understand / design / evaluate framing it sets up at the top of the deck and mapping it onto the three assignments.

## Checks

- 52 → 49 slides in L1 (course total 565 → 566), buying back time for the week-1 activities
- `make reveal` and `make beamer` both clean; all 12 decks build
- `find_unused_images.py` reports the same 2 pre-existing unused images as `main` — nothing orphaned by the moves
- Branched from `main`, so the uncommitted genAI-referencing tweak in the working checkout is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)